### PR TITLE
Feat/en ko search api

### DIFF
--- a/neural_search/Dockerfile
+++ b/neural_search/Dockerfile
@@ -10,7 +10,8 @@ ADD requirements.txt /app/
 RUN pip3 install -r requirements.txt
 
 ENV CHROMADB_PATH "/chroma"
-ENV EMBEDDING_MODEL "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
+ENV EMBEDDING_MODEL_EN "sentence-transformers/multi-qa-mpnet-base-cos-v1"
+ENV EMBEDDING_MODEL_KO "Huffon/sentence-klue-roberta-base"
 
 # Move required resources                     
 COPY ./api /app/api/

--- a/neural_search/api/chroma.py
+++ b/neural_search/api/chroma.py
@@ -5,16 +5,22 @@ from api.utils import sha256
 
 client = chromadb.PersistentClient(path=os.environ["CHROMADB_PATH"])
 
-emb_func = SentenceTransformerEmbeddingFunction(
-    model_name= os.environ.get('EMBEDDING_MODEL'),
-    device="cuda"
-)
+emb_func = {
+    "en": SentenceTransformerEmbeddingFunction(
+        model_name= os.environ.get('EMBEDDING_MODEL_EN'),
+        device="cuda"
+    ),
+    "ko": SentenceTransformerEmbeddingFunction(
+        model_name= os.environ.get('EMBEDDING_MODEL_KO'),
+        device="cuda"
+    ),
+}
 
 def create_collection(collection_name: str, metadata: dict = None):
     if not metadata:
         metadata = None
     return client.get_or_create_collection(name=collection_name,
-                                        embedding_function=emb_func,
+                                        # embedding_function=emb_func,
                                         metadata=metadata)
     
 def check_collection(collection_name: str):
@@ -23,7 +29,7 @@ def check_collection(collection_name: str):
 def delete_collection(collection_name: str):
     return client.delete_collection(collection_name)
 
-def index_documents(collection_name: str, document: dict):
+def index_documents(collection_name: str, lang: str, document: dict):
     texts = [item.document for item in document]
     metadatas = [item.metadata for item in document]
     for i, metadata in enumerate(metadatas):
@@ -32,16 +38,16 @@ def index_documents(collection_name: str, document: dict):
     ids = [sha256(text) for text in texts]
     
     collection = client.get_collection(collection_name,
-                                       embedding_function=emb_func)
+                                       embedding_function=emb_func[lang])
     collection.upsert(
         documents=texts,
         metadatas=metadatas,
         ids=ids
     )
 
-def search_documents(collection_name: str, query: str, top_k: int):
+def search_documents(collection_name: str, lang: str, query: str, top_k: int):
     collection = client.get_collection(collection_name,
-                                       embedding_function=emb_func)
+                                       embedding_function=emb_func[lang])
     results = collection.query(
         query_texts=query,
         n_results=top_k,

--- a/neural_search/api/chroma.py
+++ b/neural_search/api/chroma.py
@@ -18,9 +18,9 @@ emb_func = {
 
 def create_collection(collection_name: str, metadata: dict = None):
     if not metadata:
-        metadata = None
+        metadata = dict()
+    metadata["hnsw:space"] = "cosine"
     return client.get_or_create_collection(name=collection_name,
-                                        # embedding_function=emb_func,
                                         metadata=metadata)
     
 def check_collection(collection_name: str):

--- a/neural_search/api/main.py
+++ b/neural_search/api/main.py
@@ -60,7 +60,7 @@ async def delete(request: DeleteRequest) -> JSONResponse:
 async def indexing(request: IndexingRequest) -> JSONResponse:
     # 문서 저장 로직
     try:
-        index_documents(request.collection_name, request.data)
+        index_documents(request.collection_name, request.lang, request.data)
         return JSONResponse(status_code=200, content={"status": "success"})
     except:
         return JSONResponse(status_code=500, content={"status": "failure"})

--- a/neural_search/api/main.py
+++ b/neural_search/api/main.py
@@ -67,10 +67,11 @@ async def indexing(request: IndexingRequest) -> JSONResponse:
 
 @app.get("/search/{collection_name}")
 async def search(collection_name: str = "text",
+                 lang: str = "en",
                  query: str = "Hi, there!",
                  top_k: int = 2) -> JSONResponse:
     try:
-        result = search_documents(collection_name, query, top_k)
+        result = search_documents(collection_name, lang, query, top_k)
         return JSONResponse(status_code=200, content={
             "status": "success",
             "result": result

--- a/neural_search/api/models.py
+++ b/neural_search/api/models.py
@@ -17,4 +17,5 @@ class Document(BaseModel):
 
 class IndexingRequest(BaseModel):
     collection_name: str = "test"
+    lang: str = "en"
     data: List[Document]


### PR DESCRIPTION
## 변경사항
- 영문/국문 embedding 2가지 나누어서 사용할 수 있도록 설정
- indexing 또는 search 시 lang 선택 가능(default: en)
- Similarity 계산 metric을 L2(default)에서 cosine을 사용하도록 변경

## API interface 변경
### 1. indexing
- get request 보낼 때 `lang` param에 `en` 또는 `ko` 설정

![CleanShot 2023-12-03 at 13 37 03@2x](https://github.com/GirinMan/HAI-2023-RAG/assets/44901828/f692f09e-7c71-406f-9953-6f98f344d704)

### 2. search
- post request 보낼 때 body의 `lang` field에 `en` 또는 `ko` 설정

![CleanShot 2023-12-03 at 13 36 16@2x](https://github.com/GirinMan/HAI-2023-RAG/assets/44901828/a89c09d8-87ac-4873-a287-ecd5dbe6f977)